### PR TITLE
修复错误

### DIFF
--- a/AssetStudio/AssetStudioGUI/Exporter.cs
+++ b/AssetStudio/AssetStudioGUI/Exporter.cs
@@ -10,13 +10,13 @@ namespace AssetStudioGUI
 {
     internal static class Exporter
     {
-        public static bool ExportTexture2D(AssetItem item, string exportPath)
+        public static bool ExportTexture2D(AssetItem item, string exportPath, out string exportFullPath)
         {
             var m_Texture2D = (Texture2D)item.Asset;
             if (Properties.Settings.Default.convertTexture)
             {
                 var type = Properties.Settings.Default.convertType;
-                if (!TryExportFile(exportPath, item, "." + type.ToString().ToLower(), out var exportFullPath))
+                if (!TryExportFile(exportPath, item, "." + type.ToString().ToLower(), out exportFullPath))
                     return false;
                 var image = m_Texture2D.ConvertToImage(true);
                 if (image == null)
@@ -32,7 +32,7 @@ namespace AssetStudioGUI
             }
             else
             {
-                if (!TryExportFile(exportPath, item, ".tex", out var exportFullPath))
+                if (!TryExportFile(exportPath, item, ".tex", out exportFullPath))
                     return false;
                 File.WriteAllBytes(exportFullPath, m_Texture2D.image_data.GetData());
                 return true;
@@ -350,7 +350,7 @@ namespace AssetStudioGUI
             switch (item.Type)
             {
                 case ClassIDType.Texture2D:
-                    return ExportTexture2D(item, exportPath);
+                    return ExportTexture2D(item, exportPath, out _);
                 case ClassIDType.AudioClip:
                     return ExportAudioClip(item, exportPath);
                 case ClassIDType.Shader:

--- a/AssetStudio/AssetStudioGUI/Studio.cs
+++ b/AssetStudio/AssetStudioGUI/Studio.cs
@@ -793,8 +793,9 @@ namespace AssetStudioGUI
                             dimension = string.Format("{0}x{1}", texture2D.m_Width, texture2D.m_Height);
                         if (texture2D.m_Width >= 512 || texture2D.m_Height >= 512)
                         {
-                            result = ExportTexture2D(item, exportPath);
+                            result = ExportTexture2D(item, exportPath, out var exportFullPath);
                             filename = filename.Replace(exportPath, "Texture2D/");
+                            rawData = File.ReadAllBytes(exportFullPath);
                         }
                         else
                         {

--- a/AssetStudio/AssetStudioGUI/Studio.cs
+++ b/AssetStudio/AssetStudioGUI/Studio.cs
@@ -761,7 +761,7 @@ namespace AssetStudioGUI
 
             if (Properties.Settings.Default.openAfterExport && exportedCount > 0)
             {
-                Process.Start(savePath);
+                OpenFolderInExplorer(savePath);
             }
 
             if (csvFile.BaseStream != null)


### PR DESCRIPTION
修复因最后打开目录失败报错，导致流程中断的问题
修复因未能正确生成导出的大于512大小的贴图的Hash，导致后续分析错误的问题（主要是不同的AssetBundle中有大量同名的资源名导致的）